### PR TITLE
Add Markdown preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A powerful, AI-enhanced note-taking application built with React, TypeScript, an
 
 ### 📝 Core Note-Taking
 - **Create and Edit Notes**: Rich text editing with real-time saving
+- **Markdown Preview**: Toggle between raw markdown and rendered view
 - **Organize with Tags**: Add and manage tags for better organization
 - **Search Functionality**: Search through notes by content or filter by tags
 - **Persistent Storage**: Notes are automatically saved to local storage

--- a/components/NoteEditor.tsx
+++ b/components/NoteEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { AiAction, Note, ImprovementOptions, SummarizeOptions, BrainstormOptions } from '../types';
 import { runAiAction } from '../services/geminiService';
 import { SaveIcon } from './icons/SaveIcon';
@@ -12,6 +12,7 @@ import ImprovementModal from './ImprovementModal';
 import SummarizeModal from './SummarizeModal';
 import BrainstormModal from './BrainstormModal';
 import TagManager from './TagManager';
+import { parseMarkdown } from '../utils/markdown';
 
 interface NoteEditorProps {
   note: Note;
@@ -35,6 +36,8 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, onUpdateNote, onDeleteNot
   const [isImproveModalOpen, setIsImproveModalOpen] = useState(false);
   const [isSummarizeModalOpen, setIsSummarizeModalOpen] = useState(false);
   const [isBrainstormModalOpen, setBrainstormModalOpen] = useState(false);
+  const [viewRaw, setViewRaw] = useState(true);
+  const previewHtml = useMemo(() => parseMarkdown(content), [content]);
 
   const handleTranscriptResult = useCallback((transcript: string) => {
     setContent(prev => (prev ? prev + ' ' : '') + transcript);
@@ -154,7 +157,15 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, onUpdateNote, onDeleteNot
             <LightBulbIcon className="w-4 h-4 text-accent" />
             <span>Brainstorm</span>
           </button>
-           <button
+          <button
+            onClick={() => setViewRaw(v => !v)}
+            disabled={isLoading || isListening}
+            className="flex items-center space-x-2 px-3 py-2 bg-secondary hover:bg-secondary/80 border border-secondary hover:border-neutral rounded-md text-caption text-text transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-accent"
+            title={viewRaw ? 'Show Preview' : 'Edit Markdown'}
+          >
+            <span>{viewRaw ? 'Preview' : 'Edit'}</span>
+          </button>
+          <button
             onClick={handleDictateClick}
             disabled={isLoading || !hasRecognitionSupport}
             className={`flex items-center space-x-2 px-3 py-2 rounded-md text-caption transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed border focus:outline-none focus:ring-2 focus:ring-accent ${
@@ -190,12 +201,19 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, onUpdateNote, onDeleteNot
         </div>
       </div>
       {error && <div className="p-4 bg-red-500/20 text-red-200 border-l-4 border-red-400 mx-6 my-4 rounded-md">{error}</div>}
-      <textarea
-        value={content}
-        onChange={handleContentChange}
-        className="flex-grow w-full p-6 bg-transparent text-text focus:outline-none resize-none text-body leading-relaxed placeholder-text-secondary"
-        placeholder="Start writing your note here, or try dictating!"
-      />
+      {viewRaw ? (
+        <textarea
+          value={content}
+          onChange={handleContentChange}
+          className="flex-grow w-full p-6 bg-transparent text-text focus:outline-none resize-none text-body leading-relaxed placeholder-text-secondary"
+          placeholder="Start writing your note here, or try dictating!"
+        />
+      ) : (
+        <div
+          className="markdown-preview flex-grow w-full p-6 overflow-y-auto text-text"
+          dangerouslySetInnerHTML={{ __html: previewHtml }}
+        />
+      )}
               <ImprovementModal
           onGeneratePrompt={handleGeneratePrompt}
         isOpen={isImproveModalOpen}

--- a/index.css
+++ b/index.css
@@ -1,3 +1,36 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.markdown-preview h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.markdown-preview h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+.markdown-preview h3 {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+.markdown-preview p {
+  margin-bottom: 0.75rem;
+}
+.markdown-preview ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+.markdown-preview code {
+  background-color: var(--color-secondary);
+  padding: 0.1rem 0.25rem;
+  border-radius: 0.25rem;
+}
+.markdown-preview pre {
+  background-color: var(--color-secondary);
+  padding: 0.75rem;
+  overflow-x: auto;
+  border-radius: 0.25rem;
+  margin-bottom: 0.75rem;
+}

--- a/utils/markdown.ts
+++ b/utils/markdown.ts
@@ -1,0 +1,35 @@
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export function parseMarkdown(src: string): string {
+  let text = escapeHtml(src);
+
+  // code blocks
+  text = text.replace(/```([\s\S]*?)```/g, (_, code) => `<pre><code>${code}</code></pre>`);
+
+  // inline code
+  text = text.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  // headings
+  text = text.replace(/^### (.*)$/gm, '<h3>$1</h3>');
+  text = text.replace(/^## (.*)$/gm, '<h2>$1</h2>');
+  text = text.replace(/^# (.*)$/gm, '<h1>$1</h1>');
+
+  // bold and italics
+  text = text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+  text = text.replace(/\*(.*?)\*/g, '<em>$1</em>');
+
+  // unordered lists
+  text = text.replace(/(^|\n)(?:- |\* )(.*(?:\n(?:- |\* ).+)*)/g, (_m, lead, block) => {
+    const items = block.split(/\n/).map(line => line.replace(/^[-*] /, ''));
+    return `${lead}<ul>${items.map(i => `<li>${i}</li>`).join('')}</ul>`;
+  });
+
+  // paragraphs
+  const parts = text.split(/\n{2,}/).filter(p => p.trim() !== '');
+  return parts.map(p => `<p>${p.replace(/\n/g, '<br/>')}</p>`).join('');
+}


### PR DESCRIPTION
## Summary
- implement a simple Markdown parser
- allow viewing notes in raw or rendered mode
- style Markdown preview
- document preview feature in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688154ec59c083318c4f1aeb66c66b35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to toggle between raw markdown editing and a rendered markdown preview in the note editor.
  * Introduced a toggle button to switch between "Edit" and "Preview" modes.
  * Enhanced markdown rendering with improved styling for headings, lists, code blocks, and more.

* **Documentation**
  * Updated README to mention the new markdown preview feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->