### PR TITLE
Fix unsafe Markdown rendering

### DIFF
--- a/components/NoteEditor.tsx
+++ b/components/NoteEditor.tsx
@@ -12,7 +12,8 @@ import ImprovementModal from './ImprovementModal';
 import SummarizeModal from './SummarizeModal';
 import BrainstormModal from './BrainstormModal';
 import TagManager from './TagManager';
-import { parseMarkdown } from '../utils/markdown';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
 
 interface NoteEditorProps {
   note: Note;
@@ -37,7 +38,7 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ note, onUpdateNote, onDeleteNot
   const [isSummarizeModalOpen, setIsSummarizeModalOpen] = useState(false);
   const [isBrainstormModalOpen, setBrainstormModalOpen] = useState(false);
   const [viewRaw, setViewRaw] = useState(true);
-  const previewHtml = useMemo(() => parseMarkdown(content), [content]);
+  const previewHtml = useMemo(() => DOMPurify.sanitize(marked(content)), [content]);
 
   const handleTranscriptResult = useCallback((transcript: string) => {
     setContent(prev => (prev ? prev + ' ' : '') + transcript);

--- a/index.css
+++ b/index.css
@@ -14,6 +14,10 @@
   font-size: 1.1rem;
   margin-bottom: 0.5rem;
 }
+.markdown-preview h4 {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
 .markdown-preview p {
   margin-bottom: 0.75rem;
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@google/genai": "^1.10.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "dompurify": "^3.0.6",
+    "marked": "^11.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Summary
- sanitize Markdown preview by switching to `marked` and `DOMPurify`
- style rendered `<h4>` elements
- add `dompurify` and `marked` as dependencies

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68815927468c8331b7b0a4a325a0dfc9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Markdown rendering in note previews with enhanced security to prevent unsafe content.
* **Style**
  * Updated styling for h4 headings in Markdown previews for consistent appearance.
* **Chores**
  * Added new dependencies to support secure and improved Markdown rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->